### PR TITLE
TODOページのタスクとWBSページのタスクを連動させて表示

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,22 +1,25 @@
-import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
-import './globals.css'
+import type { Metadata } from 'next';
+import { Inter } from 'next/font/google';
+import './globals.css';
+import { TaskProvider } from '@/contexts/TaskContext';
 
-const inter = Inter({ subsets: ['latin'] })
+const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
   title: 'プロジェクト管理',
   description: 'プロジェクト管理システム',
-}
+};
 
 export default function RootLayout({
   children,
 }: {
-  children: React.ReactNode
+  children: React.ReactNode;
 }) {
   return (
     <html lang="ja">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <TaskProvider>{children}</TaskProvider>
+      </body>
     </html>
-  )
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,130 +1,98 @@
-'use client'
+'use client';
 
-import { useState } from 'react'
-import Sidebar from '@/components/Sidebar'
-import Header from '@/components/Header'
-import TaskDetail from '@/components/TaskDetail'
-import TodayTodo from '@/components/TodayTodo'
-import AdditionalTask from '@/components/AdditionalTask'
-import ProjectDetail from '@/components/ProjectDetail'
-import WeeklySchedule from '@/components/WeeklySchedule'
-import Auth from '@/components/Auth'
-import { useAuth } from '@/hooks/useAuth'
-import { Task } from '@/types/task'
+import { useState } from 'react';
+import Sidebar from '@/components/Sidebar';
+import Header from '@/components/Header';
+import TaskDetail from '@/components/TaskDetail';
+import TodayTodo from '@/components/TodayTodo';
+import AdditionalTask from '@/components/AdditionalTask';
+import ProjectDetail from '@/components/ProjectDetail';
+import WeeklySchedule from '@/components/WeeklySchedule';
+import Auth from '@/components/Auth';
+import { useAuth } from '@/hooks/useAuth';
+import { Task } from '@/types/task';
+import { useTaskContext } from '@/contexts/TaskContext';
 
 export default function Home() {
-  const { isAuthenticated, login, logout } = useAuth()
-  const [activeTab, setActiveTab] = useState('todo')
-  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null)
-  const [tasks, setTasks] = useState<Task[]>([
-    {
-      id: '1',
-      title: 'プロジェクトMTG',
-      description: 'プロジェクトの進捗確認と今後の方針について討議します。\n主な議題：\n1. 現在の進捗状況\n2. リスクの確認\n3. 次週の作業計画',
-      todos: [
-        { id: '1-1', text: '議事録の作成', completed: false, dueDate: new Date(2025, 2, 5), estimatedHours: 2 },
-        { id: '1-2', text: '参加者への資料共有', completed: false, dueDate: new Date(2025, 2, 10), estimatedHours: 1 },
-        { id: '1-3', text: '次回MTGの日程調整', completed: false, dueDate: new Date(2025, 2, 15), estimatedHours: 0.5 }
-      ],
-      isNew: true
-    },
-    {
-      id: '2',
-      title: '要件定義',
-      description: 'システムの要件定義を行います。\n機能要件と非機能要件を明確化し、ステークホルダーと合意を取ります。',
-      todos: [
-        { id: '2-1', text: '機能要件の洗い出し', completed: true, dueDate: new Date(2025, 2, 20), estimatedHours: 8 },
-        { id: '2-2', text: '非機能要件の定義', completed: false, dueDate: new Date(2025, 2, 25), estimatedHours: 4 },
-        { id: '2-3', text: 'ステークホルダーとの合意', completed: false, dueDate: new Date(2025, 2, 28), estimatedHours: 2 }
-      ],
-      isNew: true
-    },
-    {
-      id: '3',
-      title: '要件定義書の作成',
-      description: '要件定義書のドラフトを作成します。\n必要な図表やユースケースも含めて文書化します。',
-      todos: [
-        { id: '3-1', text: '目次の作成', completed: false, dueDate: new Date(2025, 2, 12), estimatedHours: 1 },
-        { id: '3-2', text: 'ユースケース図の作成', completed: false, dueDate: new Date(2025, 2, 18), estimatedHours: 4 },
-        { id: '3-3', text: 'レビュー依頼', completed: false, dueDate: new Date(2025, 2, 31), estimatedHours: 1 }
-      ]
-    }
-  ])
+  const { isAuthenticated, login, logout } = useAuth();
+  const [activeTab, setActiveTab] = useState('todo');
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const { tasks, setTasks } = useTaskContext();
 
   // WeeklyScheduleのイベントをTaskDetailで表示するための関数
   const handleTaskSelect = (taskId: string) => {
-    setSelectedTaskId(taskId)
-  }
+    setSelectedTaskId(taskId);
+  };
 
   // タスクの更新処理
   const handleTaskUpdate = (updatedTask: Task) => {
-    setTasks(prevTasks =>
-      prevTasks.map(task =>
-        task.id === updatedTask.id ? updatedTask : task
-      )
-    )
-  }
+    setTasks((prevTasks) =>
+      prevTasks.map((task) => (task.id === updatedTask.id ? updatedTask : task))
+    );
+  };
 
   // TODOの完了状態を更新
   const handleTodoStatusChange = (taskId: string, todoId: string) => {
-    setTasks(prevTasks =>
-      prevTasks.map(task => {
+    setTasks((prevTasks) =>
+      prevTasks.map((task) => {
         if (task.id === taskId) {
           return {
             ...task,
-            todos: task.todos.map(todo =>
-              todo.id === todoId ? { ...todo, completed: !todo.completed } : todo
-            )
-          }
+            todos: task.todos.map((todo) =>
+              todo.id === todoId
+                ? { ...todo, completed: !todo.completed }
+                : todo
+            ),
+          };
         }
-        return task
+        return task;
       })
-    )
-  }
+    );
+  };
 
   const handleTodoUpdate = (todoId: string, taskId: string, newDate: Date) => {
-    setTasks(prevTasks => {
-      const updatedTasks = prevTasks.map(task => {
+    setTasks((prevTasks) => {
+      const updatedTasks = prevTasks.map((task) => {
         if (task.id === taskId) {
           return {
             ...task,
-            todos: task.todos.map(todo => {
+            todos: task.todos.map((todo) => {
               if (todo.id === todoId) {
                 // 既存のTODOの日付と時間を更新
-                const updatedDueDate = new Date(newDate)
+                const updatedDueDate = new Date(newDate);
                 // 時間を保持
-                updatedDueDate.setHours(newDate.getHours())
-                updatedDueDate.setMinutes(0)
-                updatedDueDate.setSeconds(0)
-                updatedDueDate.setMilliseconds(0)
+                updatedDueDate.setHours(newDate.getHours());
+                updatedDueDate.setMinutes(0);
+                updatedDueDate.setSeconds(0);
+                updatedDueDate.setMilliseconds(0);
 
                 return {
                   ...todo,
-                  dueDate: updatedDueDate
-                }
+                  dueDate: updatedDueDate,
+                };
               }
-              return todo
-            })
-          }
+              return todo;
+            }),
+          };
         }
-        return task
-      })
-      return updatedTasks
-    })
-  }
+        return task;
+      });
+      return updatedTasks;
+    });
+  };
 
   if (!isAuthenticated) {
-    return <Auth onLogin={login} />
+    return <Auth onLogin={login} />;
   }
 
   // 選択されたタスクを取得
   const selectedTask = selectedTaskId
-    ? tasks.find(task => task.id === selectedTaskId) || null
-    : null
+    ? tasks.find((task) => task.id === selectedTaskId) || null
+    : null;
 
   return (
     <div className="flex h-screen bg-gray-100">
-      <div className="w-36 flex-shrink-0 flex flex-col">
+      <div className="flex-shrink-0 flex flex-col">
         <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
         <div className="p-2">
           <ProjectDetail />
@@ -168,5 +136,5 @@ export default function Home() {
         </main>
       </div>
     </div>
-  )
-} 
+  );
+}

--- a/src/app/wbs/page.tsx
+++ b/src/app/wbs/page.tsx
@@ -1,18 +1,18 @@
-'use client'
+'use client';
 
-import { useState } from 'react'
-import Sidebar from '@/components/Sidebar'
-import Header from '@/components/Header'
-import WBSView from '@/components/WBSView'
-import Auth from '@/components/Auth'
-import { useAuth } from '@/hooks/useAuth'
+import { useState } from 'react';
+import Sidebar from '@/components/Sidebar';
+import Header from '@/components/Header';
+import WBSView from '@/components/WBSView';
+import Auth from '@/components/Auth';
+import { useAuth } from '@/hooks/useAuth';
 
 export default function WBSPage() {
-  const { isAuthenticated, login, logout } = useAuth()
-  const [activeTab, setActiveTab] = useState('wbs')
+  const { isAuthenticated, login, logout } = useAuth();
+  const [activeTab, setActiveTab] = useState('wbs');
 
   if (!isAuthenticated) {
-    return <Auth onLogin={login} />
+    return <Auth onLogin={login} />;
   }
 
   return (
@@ -23,14 +23,14 @@ export default function WBSPage() {
         <main className="flex-1 overflow-y-auto p-6">
           <div className="bg-white rounded-lg shadow">
             <div className="p-6 border-b">
-              <h1 className="text-2xl font-bold">WBS（Work Breakdown Structure）</h1>
+              <h1 className="text-2xl font-bold">
+                WBS（Work Breakdown Structure）
+              </h1>
             </div>
-            <div className="p-6">
-              <WBSView />
-            </div>
+            <WBSView />
           </div>
         </main>
       </div>
     </div>
-  )
-} 
+  );
+}

--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -124,10 +124,15 @@ export default function TaskDetail({ selectedTask, onTaskUpdate, tasks, onTaskSe
   // 新しいTODOの追加
   const handleAddTodo = () => {
     if (editedTask && newTodoText.trim()) {
+      const today = new Date()
+      const formattedDate = today.toISOString().split('T')[0] // YYYY-MM-DD形式
+      
       const newTodo: Todo = {
         id: `todo-${Date.now()}`,
         text: newTodoText.trim(),
         completed: false,
+        startDate: formattedDate,
+        endDate: formattedDate,
         dueDate: new Date(),
         estimatedHours: 0 // デフォルトの見積もり工数を0時間に設定
       }
@@ -251,10 +256,15 @@ export default function TaskDetail({ selectedTask, onTaskUpdate, tasks, onTaskSe
 
     const taskToUpdate = editedTask || selectedTask
     if (taskToUpdate) {
+      const today = new Date()
+      const formattedDate = today.toISOString().split('T')[0] // YYYY-MM-DD形式
+      
       const newTodo: Todo = {
         id: `todo-${Date.now()}`,
         text: suggestion.text,
         completed: false,
+        startDate: formattedDate,
+        endDate: formattedDate,
         dueDate: new Date(),
         estimatedHours: suggestion.estimatedHours
       }

--- a/src/components/TodayTodo.tsx
+++ b/src/components/TodayTodo.tsx
@@ -1,75 +1,84 @@
-'use client'
+'use client';
 
-import React from 'react'
-import { format, isBefore, isToday, addDays, startOfDay, endOfDay, parseISO } from 'date-fns'
-import { ja } from 'date-fns/locale'
-import { Task, Todo } from '@/types/task'
+import React from 'react';
+import {
+  format,
+  isBefore,
+  isToday,
+  addDays,
+  startOfDay,
+  endOfDay,
+  parseISO,
+} from 'date-fns';
+import { ja } from 'date-fns/locale';
+import { Task, Todo } from '@/types/task';
 
 interface TodayTodoProps {
-  tasks: Task[]
-  selectedTaskId: string | null
-  onTaskSelect: (taskId: string) => void
-  onTodoStatusChange: (taskId: string, todoId: string) => void
+  tasks: Task[];
+  selectedTaskId: string | null;
+  onTaskSelect: (taskId: string) => void;
+  onTodoStatusChange: (taskId: string, todoId: string) => void;
 }
 
 export default function TodayTodo({
   tasks,
   selectedTaskId,
   onTaskSelect,
-  onTodoStatusChange
+  onTodoStatusChange,
 }: TodayTodoProps) {
   // 全タスクからTODOを抽出し、親タスク情報と一緒にフラット化
-  const allTodos = tasks.flatMap(task => 
-    task.todos.map(todo => ({
+  const allTodos = tasks.flatMap((task) =>
+    task.todos.map((todo) => ({
       ...todo,
       taskId: task.id,
       taskTitle: task.title,
-      isNew: task.isNew
+      isNew: task.isNew,
     }))
-  )
+  );
 
   // 期日が過ぎているか今日が期日、または3日以内に期日が来るTODOをフィルタリング
-  const filteredTodos = allTodos.filter(todo => {
-    const today = startOfDay(new Date())
-    const threeDaysFromNow = endOfDay(addDays(today, 2)) // 2日後の終わりまで（今日を0日目とカウント）
-    const todoDueDate = todo.dueDate instanceof Date ? todo.dueDate : new Date(todo.dueDate)
-    
-    console.log('Todo:', todo.text, 'Due date:', todoDueDate, 'Is before today:', isBefore(todoDueDate, today), 'Is today:', isToday(todoDueDate), 'Is within 3 days:', isBefore(todoDueDate, threeDaysFromNow))
-    
+  const filteredTodos = allTodos.filter((todo) => {
+    const today = startOfDay(new Date());
+    const threeDaysFromNow = endOfDay(addDays(today, 2)); // 2日後の終わりまで（今日を0日目とカウント）
+    const todoDueDate =
+      todo.dueDate instanceof Date ? todo.dueDate : new Date(todo.dueDate);
+
     return (
       isBefore(todoDueDate, today) || // 期日超過
       isToday(todoDueDate) || // 今日が期日
       (isBefore(today, todoDueDate) && isBefore(todoDueDate, threeDaysFromNow)) // 3日以内
-    )
-  })
+    );
+  });
 
   // 期日でソート（期日超過 → 今日が期日 → 期日が近い順）
   const sortedTodos = [...filteredTodos].sort((a, b) => {
-    const today = startOfDay(new Date())
-    const aDueDate = a.dueDate instanceof Date ? a.dueDate : new Date(a.dueDate)
-    const bDueDate = b.dueDate instanceof Date ? b.dueDate : new Date(b.dueDate)
-    const aIsOverdue = isBefore(aDueDate, today)
-    const bIsOverdue = isBefore(bDueDate, today)
-    const aIsToday = isToday(aDueDate)
-    const bIsToday = isToday(bDueDate)
+    const today = startOfDay(new Date());
+    const aDueDate =
+      a.dueDate instanceof Date ? a.dueDate : new Date(a.dueDate);
+    const bDueDate =
+      b.dueDate instanceof Date ? b.dueDate : new Date(b.dueDate);
+    const aIsOverdue = isBefore(aDueDate, today);
+    const bIsOverdue = isBefore(bDueDate, today);
+    const aIsToday = isToday(aDueDate);
+    const bIsToday = isToday(bDueDate);
 
-    if (aIsOverdue !== bIsOverdue) return aIsOverdue ? -1 : 1
-    if (aIsToday !== bIsToday) return aIsToday ? -1 : 1
-    return aDueDate.getTime() - bDueDate.getTime()
-  })
+    if (aIsOverdue !== bIsOverdue) return aIsOverdue ? -1 : 1;
+    if (aIsToday !== bIsToday) return aIsToday ? -1 : 1;
+    return aDueDate.getTime() - bDueDate.getTime();
+  });
 
   // 期日の状態に応じたスタイルを返す関数
   const getDueDateStyle = (dueDate: Date | string) => {
-    const today = startOfDay(new Date())
-    const dueDateObj = dueDate instanceof Date ? dueDate : new Date(dueDate)
+    const today = startOfDay(new Date());
+    const dueDateObj = dueDate instanceof Date ? dueDate : new Date(dueDate);
     if (isBefore(dueDateObj, today)) {
-      return 'text-red-500' // 期日超過
+      return 'text-red-500'; // 期日超過
     }
     if (isToday(dueDateObj)) {
-      return 'text-orange-500' // 今日が期日
+      return 'text-orange-500'; // 今日が期日
     }
-    return 'text-blue-500' // 期日が近い
-  }
+    return 'text-blue-500'; // 期日が近い
+  };
 
   return (
     <div className="bg-white rounded-lg shadow p-3">
@@ -91,12 +100,16 @@ export default function TodayTodo({
                   type="checkbox"
                   checked={todo.completed}
                   onChange={(e) => {
-                    e.stopPropagation()
-                    onTodoStatusChange(todo.taskId, todo.id)
+                    e.stopPropagation();
+                    onTodoStatusChange(todo.taskId, todo.id);
                   }}
                   className="w-4 h-4"
                 />
-                <span className={`text-sm ${todo.completed ? 'line-through text-gray-500' : ''}`}>
+                <span
+                  className={`text-sm ${
+                    todo.completed ? 'line-through text-gray-500' : ''
+                  }`}
+                >
                   {todo.text}
                 </span>
               </div>
@@ -111,9 +124,7 @@ export default function TodayTodo({
                 )}
               </div>
             </div>
-            <div className="ml-6 text-xs text-gray-500">
-              {todo.taskTitle}
-            </div>
+            <div className="ml-6 text-xs text-gray-500">{todo.taskTitle}</div>
           </div>
         ))}
       </div>
@@ -123,5 +134,5 @@ export default function TodayTodo({
         </a>
       </div>
     </div>
-  )
-} 
+  );
+}

--- a/src/contexts/TaskContext.tsx
+++ b/src/contexts/TaskContext.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { createContext, useContext, useState, ReactNode } from 'react';
+import { Task } from '@/types/task';
+
+interface TaskContextType {
+  tasks: Task[];
+  setTasks: React.Dispatch<React.SetStateAction<Task[]>>;
+}
+
+const TaskContext = createContext<TaskContextType | undefined>(undefined);
+
+export const TaskProvider = ({ children }: { children: ReactNode }) => {
+  const [tasks, setTasks] = useState<Task[]>([
+    {
+      id: '1',
+      title: 'プロジェクトMTG',
+      description:
+        'プロジェクトの進捗確認と今後の方針について討議します。\n主な議題：\n1. 現在の進捗状況\n2. リスクの確認\n3. 次週の作業計画',
+      startDate: '2025-03-01',
+      endDate: '2025-03-15',
+      todos: [
+        {
+          id: '1-1',
+          text: '議事録の作成',
+          completed: true,
+          dueDate: new Date(2025, 2, 5),
+          estimatedHours: 2,
+          startDate: '2025-03-01',
+          endDate: '2025-03-05',
+        },
+        {
+          id: '1-2',
+          text: '参加者への資料共有',
+          completed: true,
+          dueDate: new Date(2025, 2, 10),
+          estimatedHours: 1,
+          startDate: '2025-03-06',
+          endDate: '2025-03-10',
+        },
+        {
+          id: '1-3',
+          text: '次回MTGの日程調整',
+          completed: false,
+          dueDate: new Date(2025, 2, 15),
+          estimatedHours: 0.5,
+          startDate: '2025-03-11',
+          endDate: '2025-03-15',
+        },
+      ],
+      isNew: true,
+    },
+    {
+      id: '2',
+      title: '要件定義',
+      description:
+        'システムの要件定義を行います。\n機能要件と非機能要件を明確化し、ステークホルダーと合意を取ります。',
+      startDate: '2025-03-16',
+      endDate: '2025-03-30',
+      todos: [
+        {
+          id: '2-1',
+          text: '機能要件の洗い出し',
+          completed: true,
+          dueDate: new Date(2025, 2, 20),
+          estimatedHours: 8,
+          startDate: '2025-03-16',
+          endDate: '2025-03-20',
+        },
+        {
+          id: '2-2',
+          text: '非機能要件の定義',
+          completed: false,
+          dueDate: new Date(2025, 2, 25),
+          estimatedHours: 4,
+          startDate: '2025-03-21',
+          endDate: '2025-03-25',
+        },
+        {
+          id: '2-3',
+          text: 'ステークホルダーとの合意',
+          completed: true,
+          dueDate: new Date(2025, 2, 28),
+          estimatedHours: 2,
+          startDate: '2025-03-26',
+          endDate: '2025-03-30',
+        },
+      ],
+      isNew: true,
+    },
+    {
+      id: '3',
+      title: '要件定義書の作成',
+      description:
+        '要件定義書のドラフトを作成します。\n必要な図表やユースケースも含めて文書化します。',
+      startDate: '2025-03-01',
+      endDate: '2025-03-31',
+      todos: [
+        {
+          id: '3-1',
+          text: '目次の作成',
+          completed: false,
+          dueDate: new Date(2025, 2, 12),
+          estimatedHours: 1,
+          startDate: '2025-03-01',
+          endDate: '2025-03-05',
+        },
+        {
+          id: '3-2',
+          text: 'ユースケース図の作成',
+          completed: false,
+          dueDate: new Date(2025, 2, 18),
+          estimatedHours: 4,
+          startDate: '2025-03-06',
+          endDate: '2025-03-10',
+        },
+        {
+          id: '3-3',
+          text: 'レビュー依頼',
+          completed: true,
+          dueDate: new Date(2025, 2, 31),
+          estimatedHours: 1,
+          startDate: '2025-03-11',
+          endDate: '2025-03-15',
+        },
+      ],
+    },
+  ]);
+
+  return (
+    <TaskContext.Provider value={{ tasks, setTasks }}>
+      {children}
+    </TaskContext.Provider>
+  );
+};
+
+export const useTaskContext = () => {
+  const context = useContext(TaskContext);
+  if (!context) {
+    throw new Error('useTaskContext must be used within a TaskProvider');
+  }
+  return context;
+};

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,15 +1,19 @@
 export interface Todo {
-  id: string
-  text: string
-  completed: boolean
-  dueDate: Date
-  estimatedHours: number // 見積もり工数（時間単位）
+  id: string;
+  text: string;
+  completed: boolean;
+  startDate: string;
+  endDate: string;
+  dueDate: Date;
+  estimatedHours: number; // 見積もり工数（時間単位）
 }
 
 export interface Task {
-  id: string
-  title: string
-  description: string
-  todos: Todo[]
-  isNew?: boolean
-} 
+  id: string;
+  title: string;
+  description: string;
+  startDate: string;
+  endDate: string;
+  todos: Todo[];
+  isNew?: boolean;
+}


### PR DESCRIPTION
やったこと
- useContextを使用して、tasks をグローバルステートで管理する
- タスクのテーブルにstartDateとendDateを追加してガントチャート表示できるようにした
- 小タスクの達成率に応じて親タスクの進捗を表示できるようにした
- TODOページにいるときにヘッダーがはみ出していたので修正した
- TODO編集でstartDateとendDateも更新できるようにした

やってないこと
- taskのテーブルをいじったせいでtaskを新規追加できなくなった。→もともとの仕様だったので、別のプルリクで修正

<img width="1710" alt="スクリーンショット 2025-03-11 16 37 26" src="https://github.com/user-attachments/assets/334ce1d3-eb86-43f2-83b9-42e350dc92fc" />
<img width="1710" alt="スクリーンショット 2025-03-11 16 37 31" src="https://github.com/user-attachments/assets/49f0a6b4-0583-4c02-b7ea-394ab64443aa" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**  
  - Introduced dynamic project management with real-time updates and detailed overviews, including an editable modal dialog for project details.
  - Added context-based task management to enhance the functionality of task-related components.

- **Enhancements**  
  - Streamlined task tracking with improved progress displays and dynamic representation of todos.
  - Updated headers and layouts to dynamically show project schedules, dates, and remaining days.

- **Chores / Style**  
  - Applied consistent formatting improvements and integrated a new UI dependency for smoother modal transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->